### PR TITLE
report success when the device is not on the last interface

### DIFF
--- a/pylon_tool.c
+++ b/pylon_tool.c
@@ -715,7 +715,14 @@ int main(int argc, char **argv) {
                 // vic_print_message("error", "No valid devices found on any CAN interface");
                 ret = PYLON_SUCCESS;
             }
-            
+
+            // When multiple interfaces are scanned and a device is found do report that as successful.
+            // Otherwise the state of the last interface will be returned and that might be
+            // PYLON_ERROR_NO_DEVICE when the device is connected to another interface.
+
+            if (list_mode && found_device)
+                ret = PYLON_SUCCESS;
+
             free_can_interfaces(can_interfaces);
         }
     }


### PR DESCRIPTION
When there are multiple CAN interfaces and the device is e.g. connected to the first one, an error PYLON_ERROR_NO_DEVICE would be returned, since there is no device found on the last interface. Instead, always return success when a device is found.

see https://community.victronenergy.com/t/pylontech-firmware-update-feature-issue/55616/12
I patched this in Venus OS  v3.72~6, which will be released as v3.72 soon.

According to ChatGPT it is something like below, but I have no idea.

// 当扫描多个接口并且发现设备时，应将其视为成功。
// 否则将返回最后一个接口的状态，而该状态可能是
// PYLON_ERROR_NO_DEVICE（当设备连接到另一个接口时）。